### PR TITLE
Comment out mraa import since it is no longer required.

### DIFF
--- a/spi_serial/spi_serial.py
+++ b/spi_serial/spi_serial.py
@@ -1,4 +1,4 @@
-import mraa as m
+#import mraa as m
 import time
 
 import gpio
@@ -60,10 +60,10 @@ class SpiSerial():
         ret_val = self.rx_buf[0:num_bytes]
         del(self.rx_buf[0:num_bytes])
         return ret_val
-        
+
     def peek(self):
         return self.rx_buf[0]
-        
+
     def pop(self):
         return self.read(1)
 


### PR DESCRIPTION
Your fork of spi_serial is currently used in the OpenAPS oref0 setup on newer kernels and the oref0 setup screipt assumed that mraa is not required so module is not loaded. 

https://github.com/openaps/oref0/blob/master/bin/oref0-setup.sh#L779

This results in a failure because the spi_serial is still trying to import the mraa module, so I commented out the import in your fork to resolve this issue.